### PR TITLE
Don't raise exception if tracker class is not defined

### DIFF
--- a/lib/action_tracker/concerns/tracker.rb
+++ b/lib/action_tracker/concerns/tracker.rb
@@ -20,12 +20,15 @@ module ActionTracker
       private
 
       def tracker_params(tracker_class, tracker_user)
-        if Object.const_defined? tracker_class
+        begin
           tracker = Object.const_get(tracker_class, false).new
           tracker.user = tracker_user
           tracker.params = params
-          tracker.method(action_name).call if tracker.respond_to? action_name
+          output = tracker.method(action_name).call if tracker.respond_to? action_name
+        rescue NameError
+          output = ''
         end
+        output
       end
 
       def namespace


### PR DESCRIPTION
Now the existence of the class is checked before it throws an exception.
Also, the `track_event` method was rewriten for a smaller version.
