### PR TITLE
Auto-set Devise resources

### DIFF
--- a/action_tracker.gemspec
+++ b/action_tracker.gemspec
@@ -23,7 +23,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activesupport', '~> 3.2'
   spec.add_dependency 'devise', '~> 3.4'
 
-  spec.add_development_dependency 'bundler', '~> 1.11'
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency "bundler", "~> 1.11"
+  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rspec-rails", "~> 3.0"
+  spec.add_development_dependency 'rails', '~> 3.2'
 end

--- a/action_tracker.gemspec
+++ b/action_tracker.gemspec
@@ -4,25 +4,26 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'action_tracker/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "action_tracker"
+  spec.name          = 'action_tracker'
   spec.version       = ActionTracker::VERSION
-  spec.authors       = ["André Taiar", "João Fraga"]
-  spec.email         = ["andre.taiar@appprova.com.br", "joaogabriel@appprova.com.br"]
+  spec.authors       = ['André Taiar', 'João Fraga']
+  spec.email         = ['andre.taiar@appprova.com.br', 'joaogabriel@appprova.com.br']
 
   spec.summary       = %q{Easy way to track actions in your application.}
   spec.description   = %q{Easy way to track actions in your application without adding unnecessary code to your controllers.}
-  spec.homepage      = "http://coders.appprova.com.br/"
-  spec.license       = "MIT"
+  spec.homepage      = 'http://coders.appprova.com.br/'
+  spec.license       = 'MIT'
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.bindir        = "exe"
+  spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
   spec.add_dependency 'rails3_before_render', '0.2.0'
   spec.add_dependency 'activesupport', '~> 3.2'
+  spec.add_dependency 'devise', '~> 3.4'
 
-  spec.add_development_dependency "bundler", "~> 1.11"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency 'bundler', '~> 1.11'
+  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rspec', '~> 3.0'
 end

--- a/lib/action_tracker/base.rb
+++ b/lib/action_tracker/base.rb
@@ -1,6 +1,11 @@
 module ActionTracker
   # nodoc
   class Base
-    attr_accessor :params, :user
+    attr_accessor :params, :resoruce
+
+    def initialize(resource, params)
+      @resource = resource
+      @params = params
+    end
   end
 end

--- a/lib/action_tracker/base.rb
+++ b/lib/action_tracker/base.rb
@@ -7,5 +7,9 @@ module ActionTracker
       @resource = resource
       @params = params
     end
+
+    def user
+      @resource
+    end
   end
 end

--- a/lib/action_tracker/base.rb
+++ b/lib/action_tracker/base.rb
@@ -1,7 +1,7 @@
 module ActionTracker
   # nodoc
   class Base
-    attr_accessor :params, :resoruce
+    attr_accessor :params, :resource
 
     def initialize(resource, params)
       @resource = resource

--- a/lib/action_tracker/base.rb
+++ b/lib/action_tracker/base.rb
@@ -1,7 +1,7 @@
 module ActionTracker
   # nodoc
   class Base
-    attr_accessor :params, :resource
+    attr_reader :params, :resource
 
     def initialize(resource, params)
       @resource = resource

--- a/lib/action_tracker/concerns/tracker.rb
+++ b/lib/action_tracker/concerns/tracker.rb
@@ -38,11 +38,11 @@ module ActionTracker
       end
 
       def tracker_params
-        return nil unless tracker_exists
+        return nil unless tracker_exists?
         tracker_instance.method(action_name).call
       end
 
-      def tracker_exists
+      def tracker_exists?
         tracker_instance && tracker_instance.respond_to?(action_name)
       end
 

--- a/lib/action_tracker/concerns/tracker.rb
+++ b/lib/action_tracker/concerns/tracker.rb
@@ -22,13 +22,15 @@ module ActionTracker
       end
 
       def resource
-        @resource ||= method(find_resource).call
+        @resource ||= method(find_resource).call unless find_resource
       end
 
       def find_resource
-        Devise.mappings.keys.map { |resource| "current_#{resource}" }
-              .select { |resource_method| !method(resource_method).call.nil? }
-              .first
+        @resource_method ||= Devise.mappings.keys.map { |resource| "current_#{resource}" }
+                                   .select { |method_name| !method(method_name).call.nil? }
+                                   .first
+      rescue NameError
+        nil
       end
 
       def tracker_instance

--- a/lib/action_tracker/concerns/tracker.rb
+++ b/lib/action_tracker/concerns/tracker.rb
@@ -1,3 +1,4 @@
+require 'active_support'
 require 'rails3_before_render'
 
 module ActionTracker

--- a/lib/action_tracker/concerns/tracker.rb
+++ b/lib/action_tracker/concerns/tracker.rb
@@ -22,10 +22,13 @@ module ActionTracker
       end
 
       def resource
-        @resource ||= method(Devise.mappings.keys
-                            .map { |resource| "current_#{resource}" }
-                            .select { |resource_method| !method(resource_method).call.nil? }
-                            .first).call
+        @resource ||= method(find_resource).call
+      end
+
+      def find_resource
+        Devise.mappings.keys.map { |resource| "current_#{resource}" }
+              .select { |resource_method| !method(resource_method).call.nil? }
+              .first
       end
 
       def tracker_instance

--- a/lib/action_tracker/concerns/tracker.rb
+++ b/lib/action_tracker/concerns/tracker.rb
@@ -22,18 +22,21 @@ module ActionTracker
       end
 
       def resource
-        @resource ||= current_user || current_teacher
+        @resource ||= method(Devise.mappings.keys
+                            .map { |resource| "current_#{resource}" }
+                            .select { |resource_method| !method(resource_method).call.nil? }
+                            .first).call
       end
 
-      def tracker
-        @tracker ||= Object.const_get(tracker_klass, false).new(resource, params)
+      def tracker_instance
+        @tracker_instance ||= Object.const_get(tracker_klass, false).new(resource, params)
       rescue NameError
         nil
       end
 
       def tracker_params
-        return nil unless tracker && !tracker.respond_to?(action_name)
-        tracker.method(action_name).call
+        return nil unless tracker_instance && tracker_instance.respond_to?(action_name)
+        tracker_instance.method(action_name).call
       end
 
       def namespace

--- a/lib/action_tracker/concerns/tracker.rb
+++ b/lib/action_tracker/concerns/tracker.rb
@@ -35,8 +35,12 @@ module ActionTracker
       end
 
       def tracker_params
-        return nil unless tracker_instance && tracker_instance.respond_to?(action_name)
+        return nil unless tracker_exists
         tracker_instance.method(action_name).call
+      end
+
+      def tracker_exists
+        tracker_instance && tracker_instance.respond_to?(action_name)
       end
 
       def namespace

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,6 @@
+require 'abstract_controller'
+require 'action_controller'
+require 'rails'
+
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'action_tracker'


### PR DESCRIPTION
This PR makes the `ActionTracker::Concerns::Tracker` class to automatically get the Devise active resource (the object representation of logged user in Devise).

**This PR keeps Devise coupling.**

There are still remaining specs but there is another PR just for that.
