### PR TITLE
Send stack of trackers

### DIFF
--- a/lib/action_tracker/concerns/tracker.rb
+++ b/lib/action_tracker/concerns/tracker.rb
@@ -16,7 +16,7 @@ module ActionTracker
         tracker_class = "#{namespace}#{controller_name.camelize}Tracker"
         session[:action_tracker] ||= []
         output = tracker_params(tracker_class, tracker_user)
-        session[:action_tracker] << output unless output.nil? || output.empty?
+        session[:action_tracker] << output unless output.blank?
       end
 
       private

--- a/lib/action_tracker/concerns/tracker.rb
+++ b/lib/action_tracker/concerns/tracker.rb
@@ -12,9 +12,11 @@ module ActionTracker
       end
 
       def track_event
-        tracker_user = current_user || current_teacher
+        tracker_user = current_user || current_teacher || resource
         tracker_class = "#{namespace}#{controller_name.camelize}Tracker"
-        @tracker_params = tracker_params(tracker_class, tracker_user)
+        session[:action_tracker] ||= []
+        output = tracker_params(tracker_class, tracker_user)
+        session[:action_tracker] << output unless output.nil? || output.empty?
       end
 
       private

--- a/lib/action_tracker/helpers/render.rb
+++ b/lib/action_tracker/helpers/render.rb
@@ -3,7 +3,9 @@ module ActionTracker
     # nodoc
     module Render
       def track_event
-        @tracker_params unless @tracker_params.nil?
+        output = session[:action_tracker].to_s
+        session[:action_tracker] = nil
+        output
       end
     end
   end


### PR DESCRIPTION
This PR collects a bunch of tracked actions in a session.

It cleans the session when a helper method is called, passing the trackers to views.

It is useful to track events in actions where is not possible to render views (like posts and redirects).
