### PR TITLE
Remove before render

### DIFF
--- a/action_tracker.gemspec
+++ b/action_tracker.gemspec
@@ -1,4 +1,3 @@
-# coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'action_tracker/version'
@@ -9,8 +8,8 @@ Gem::Specification.new do |spec|
   spec.authors       = ['André Taiar', 'João Fraga']
   spec.email         = ['andre.taiar@appprova.com.br', 'joaogabriel@appprova.com.br']
 
-  spec.summary       = %q{Easy way to track actions in your application.}
-  spec.description   = %q{Easy way to track actions in your application without adding unnecessary code to your controllers.}
+  spec.summary       = 'Easy way to track actions in your application.'
+  spec.description   = 'Easy way to track actions in your application without adding unnecessary code to your controllers.'
   spec.homepage      = 'http://coders.appprova.com.br/'
   spec.license       = 'MIT'
 
@@ -19,12 +18,11 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rails3_before_render', '0.2.0'
   spec.add_dependency 'activesupport', '~> 3.2'
   spec.add_dependency 'devise', '~> 3.4'
 
-  spec.add_development_dependency "bundler", "~> 1.11"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec-rails", "~> 3.0"
+  spec.add_development_dependency 'bundler', '~> 1.11'
+  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rspec-rails', '~> 3.0'
   spec.add_development_dependency 'rails', '~> 3.2'
 end

--- a/lib/action_tracker/base.rb
+++ b/lib/action_tracker/base.rb
@@ -16,6 +16,5 @@ module ActionTracker
         instance_variable_set(instance_var, kontroller.instance_variable_get(instance_var))
       end
     end
-
   end
 end

--- a/lib/action_tracker/concerns/tracker.rb
+++ b/lib/action_tracker/concerns/tracker.rb
@@ -1,5 +1,4 @@
 require 'active_support'
-require 'rails3_before_render'
 
 module ActionTracker
   module Concerns
@@ -9,7 +8,7 @@ module ActionTracker
 
       included do
         helper ActionTracker::Helpers::Render
-        before_render :track_event
+        after_filter :track_event
       end
 
       def track_event

--- a/lib/action_tracker/helpers/render.rb
+++ b/lib/action_tracker/helpers/render.rb
@@ -4,7 +4,7 @@ module ActionTracker
     module Render
       def track_event
         return unless session[:action_tracker].present?
-        output = session[:action_tracker].flatten.to_s
+        output = session[:action_tracker].flatten
         session[:action_tracker] = nil
         output
       end


### PR DESCRIPTION
This PR is intended to improve the gem behaviour for actions that do not render a view (PUT or POST), by using a after_filter instead of a before_render.
