### PR TITLE
Override render on concern for real-time tracking on get ations

### DIFF
--- a/lib/action_tracker/concerns/tracker.rb
+++ b/lib/action_tracker/concerns/tracker.rb
@@ -11,6 +11,11 @@ module ActionTracker
         after_filter :track_event
       end
 
+      def render(*args)
+        track_event
+        super
+      end
+
       def track_event
         session[:action_tracker] ||= []
         session[:action_tracker] << tracker_params unless tracker_params.blank?


### PR DESCRIPTION
For GET action, the `track_event` method is called after the view render. This PR is intended solve this problem, calling the `track_event` to be called before the render.
