### PR TITLE
Configuration options

### DIFF
--- a/lib/action_tracker.rb
+++ b/lib/action_tracker.rb
@@ -2,6 +2,7 @@ require 'action_tracker/version'
 require 'action_tracker/concerns/tracker'
 require 'action_tracker/helpers/render'
 require 'action_tracker/base'
+require 'action_tracker/configuration'
 
 # nodoc
 module ActionTracker

--- a/lib/action_tracker/configuration.rb
+++ b/lib/action_tracker/configuration.rb
@@ -1,0 +1,19 @@
+module ActionTracker
+  class << self
+    attr_accessor :configuration
+  end
+
+  def self.configure
+    self.configuration ||= Configuration.new
+    yield(configuration)
+  end
+
+  # nodoc
+  class Configuration
+    attr_accessor :active
+
+    def initialize
+      @active = true
+    end
+  end
+end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe ActionTracker::Configuration do
+  describe "#active flag" do
+    it "default value is true" do
+      ActionTracker::Configuration.new.active = true
+    end
+  end
+
+  describe "#active flag=" do
+    it "can set value" do
+      config = ActionTracker::Configuration.new
+      config.active = false
+      expect(config.active).to be_falsy
+    end
+  end
+end


### PR DESCRIPTION
This PR intends to insert configurations in this gem.

The first one will be an `active` parameter that will activate or not the tracker functionality.
