### PR TITLE
creating conditional events tracking

### DIFF
--- a/lib/action_tracker.rb
+++ b/lib/action_tracker.rb
@@ -2,29 +2,12 @@ require 'action_tracker/version'
 require 'action_tracker/concerns/tracker'
 require 'action_tracker/helpers/render'
 require 'action_tracker/base'
+require 'action_tracker/configuration'
 
 # nodoc
 module ActionTracker
-  class << self
-    attr_accessor :configuration
-  end
-
-  def self.configure
-    self.configuration ||= Configuration.new
-    yield(configuration)
-  end
-
   if defined?(Rails)
     require 'action_tracker/engine'
     ActiveSupport.on_load(:action_controller) { include ActionTracker::Concerns::Tracker }
-  end
-
-  # nodoc
-  class Configuration
-    attr_accessor :track_events
-
-    def initialize
-      @track_events = true
-    end
   end
 end

--- a/lib/action_tracker.rb
+++ b/lib/action_tracker.rb
@@ -5,8 +5,26 @@ require 'action_tracker/base'
 
 # nodoc
 module ActionTracker
+  class << self
+    attr_accessor :configuration
+  end
+
+  def self.configure
+    self.configuration ||= Configuration.new
+    yield(configuration)
+  end
+
   if defined?(Rails)
     require 'action_tracker/engine'
     ActiveSupport.on_load(:action_controller) { include ActionTracker::Concerns::Tracker }
+  end
+
+  # nodoc
+  class Configuration
+    attr_accessor :track_events
+
+    def initialize
+      @track_events = true
+    end
   end
 end

--- a/lib/action_tracker/concerns/tracker.rb
+++ b/lib/action_tracker/concerns/tracker.rb
@@ -29,6 +29,7 @@ module ActionTracker
       end
 
       def track_event
+        return unless ActionTracker.configuration.track_events
         session[:action_tracker] ||= []
         session[:action_tracker] << tracker_params unless tracker_params.blank?
       end

--- a/lib/action_tracker/configuration.rb
+++ b/lib/action_tracker/configuration.rb
@@ -2,10 +2,13 @@
 module ActionTracker
   class << self
     attr_accessor :configuration
+
+    def configuration
+      @configuration ||= Configuration.new
+    end
   end
 
   def self.configure
-    self.configuration ||= Configuration.new
     yield(configuration)
   end
 

--- a/lib/action_tracker/configuration.rb
+++ b/lib/action_tracker/configuration.rb
@@ -1,0 +1,20 @@
+# nodoc
+module ActionTracker
+  class << self
+    attr_accessor :configuration
+  end
+
+  def self.configure
+    self.configuration ||= Configuration.new
+    yield(configuration)
+  end
+
+  # nodoc
+  class Configuration
+    attr_accessor :track_events
+
+    def initialize
+      @track_events = true
+    end
+  end
+end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,17 +1,27 @@
 require 'spec_helper'
 
 describe ActionTracker::Configuration do
-  describe '#track_events flag' do
+  describe '#track_events' do
     it 'default value is true' do
-      expect(ActionTracker::Configuration.new.track_events).to eq(true)
+      expect(ActionTracker.configuration.track_events).to eq(true)
     end
   end
 
-  describe '#track_events flag=' do
-    it 'can set value' do
-      config = ActionTracker::Configuration.new
-      config.track_events = false
-      expect(config.track_events).to be_falsy
+  context '#track_events false' do
+    before(:each) do
+      ActionTracker.configure do |config|
+        config.track_events = false
+      end
+    end
+
+    after(:each) do
+      ActionTracker.configure do |config|
+        config.track_events = true
+      end
+    end
+
+    it 'can be setted to false' do
+      expect(ActionTracker.configuration.track_events).to eq(false)
     end
   end
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe ActionTracker::Configuration do
+  describe '#track_events flag' do
+    it 'default value is true' do
+      ActionTracker::Configuration.new.track_events = true
+    end
+  end
+
+  describe '#track_events flag=' do
+    it 'can set value' do
+      config = ActionTracker::Configuration.new
+      config.track_events = false
+      expect(config.track_events).to be_falsy
+    end
+  end
+end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe ActionTracker::Configuration do
   describe '#track_events flag' do
     it 'default value is true' do
-      ActionTracker::Configuration.new.track_events = true
+      expect(ActionTracker::Configuration.new.track_events).to eq(true)
     end
   end
 

--- a/spec/tracker_spec.rb
+++ b/spec/tracker_spec.rb
@@ -8,7 +8,6 @@ describe ActionTracker::Concerns::Tracker do
     @fake_session = {}
 
     allow_any_instance_of(ApplicationTestController).to receive(:session).and_return(@fake_session)
-    allow(ActionTracker).to receive_message_chain([:configuration, :track_events]).and_return(true)
     @helper = Object.new.extend ActionTracker::Helpers::Render
   end
 

--- a/spec/tracker_spec.rb
+++ b/spec/tracker_spec.rb
@@ -3,12 +3,12 @@ require 'spec_helper'
 include ActionTracker::Helpers::Render
 
 describe ActionTracker::Concerns::Tracker do
-
   before(:each) do
     @event_list = []
     @fake_session = {}
 
     allow_any_instance_of(ApplicationTestController).to receive(:session).and_return(@fake_session)
+    allow(ActionTracker).to receive_message_chain([:configuration, :track_events]).and_return(true)
     @helper = Object.new.extend ActionTracker::Helpers::Render
   end
 
@@ -25,7 +25,7 @@ describe ActionTracker::Concerns::Tracker do
   end
 
   it 'stacks sequence of trackers' do
-    trigger_trackers(['action_test', 'another_action_test'])
+    trigger_trackers(%w(action_test another_action_test))
 
     expect(@fake_session[:action_tracker].size).to eq(2)
     expect(@fake_session[:action_tracker].first).to eq('Here comes the test')
@@ -33,7 +33,7 @@ describe ActionTracker::Concerns::Tracker do
   end
 
   it 'clear stacks sequence of trackers when the helper is called' do
-    trigger_trackers(['action_test', 'another_action_test'])
+    trigger_trackers(%w(action_test another_action_test))
 
     expect(@fake_session[:action_tracker].size).to eq(2)
 
@@ -47,10 +47,9 @@ describe ActionTracker::Concerns::Tracker do
 
   def trigger_trackers(event_list)
     event_list.size.times do |n|
-      @event_list[n] = ApplicationTestController.new { include ActionTracker::Concerns::Tracker  }
+      @event_list[n] = ApplicationTestController.new { include ActionTracker::Concerns::Tracker }
       allow(@event_list[n]).to receive(:action_name).and_return(event_list[n])
-      @event_list[n].instance_eval{ track_event }
+      @event_list[n].instance_eval { track_event }
     end
   end
-
 end


### PR DESCRIPTION
On this PR, it's implemented a custom configuration to enable or disable the events tracking on a application initializer. It is defaulted to `true`, but, if necessary, the implementing application can set it to `false`, in order to stop the application of setting session variables for the user.
