### PR TITLE
Feature/track matcher

### DIFF
--- a/lib/action_tracker/matchers.rb
+++ b/lib/action_tracker/matchers.rb
@@ -1,1 +1,2 @@
 require 'action_tracker/matchers/have_action_tracker_matcher'
+require 'action_tracker/matchers/track_matcher'

--- a/lib/action_tracker/matchers/have_action_tracker_matcher.rb
+++ b/lib/action_tracker/matchers/have_action_tracker_matcher.rb
@@ -10,11 +10,11 @@ RSpec::Matchers.define :have_action_tracker do
   end
 
   failure_message do |actual|
-    "expected that #{actual} to have ActionTracker, but it didn't."
+    "expected that #{actual} to include ActionTracker, but it didn't."
   end
 
   failure_message_when_negated do |actual|
-    "expected that #{actual} not to have ActionTracker, but it did."
+    "expected that #{actual} not to include ActionTracker, but it did."
   end
 
   private

--- a/lib/action_tracker/matchers/have_action_tracker_matcher.rb
+++ b/lib/action_tracker/matchers/have_action_tracker_matcher.rb
@@ -1,17 +1,29 @@
 RSpec::Matchers.define :have_action_tracker do
   match do |actual|
-    actual.respond_to? 'track_event'
+    actual.class.included_modules.include? ActionTracker::Concerns::Tracker
+    filter_exists?(controller, :before, :initialize_session)
+    filter_exists?(controller, :after, :conditional_track_event)
   end
 
   description do
-    "responds to #track_event."
+    "have ActionTracker."
   end
 
   failure_message do |actual|
-    "expected that #{actual} responded to #track_event, but it didn't."
+    "expected that #{actual} to have ActionTracker, but it didn't."
   end
 
   failure_message_when_negated do |actual|
-    "expected that #{actual} would not respond to #track_event, but it did."
+    "expected that #{actual} not to have ActionTracker, but it did."
   end
+
+  private
+
+  def filter_exists?(controller, kind, filter)
+    controller.class
+      ._process_action_callbacks
+      .select {|f| f.kind == kind }
+      .map(&:filter).include? filter
+  end
+
 end

--- a/lib/action_tracker/matchers/have_action_tracker_matcher.rb
+++ b/lib/action_tracker/matchers/have_action_tracker_matcher.rb
@@ -1,7 +1,7 @@
 RSpec::Matchers.define :have_action_tracker do
   match do |actual|
-    actual.class.included_modules.include? ActionTracker::Concerns::Tracker
-    filter_exists?(controller, :before, :initialize_session)
+    actual.class.included_modules.include?(ActionTracker::Concerns::Tracker) &&
+    filter_exists?(controller, :before, :initialize_session) &&
     filter_exists?(controller, :after, :conditional_track_event)
   end
 

--- a/lib/action_tracker/matchers/track_matcher.rb
+++ b/lib/action_tracker/matchers/track_matcher.rb
@@ -1,0 +1,18 @@
+RSpec::Matchers.define :track do |expected|
+  match do |actual|
+    actual.send(:tracker_instance).respond_to?(expected)
+  end
+
+  description do
+    "track #{expected}."
+  end
+
+  failure_message do |actual|
+    "expected that #{actual} track #{expected} action, but it didn't."
+  end
+
+  failure_message_when_negated do |actual|
+    "expected that #{actual} doesn't track #{expected} action, but it did."
+  end
+
+end

--- a/lib/action_tracker/matchers/track_matcher.rb
+++ b/lib/action_tracker/matchers/track_matcher.rb
@@ -8,11 +8,11 @@ RSpec::Matchers.define :track do |expected|
   end
 
   failure_message do |actual|
-    "expected that #{actual} track #{expected} action, but it didn't."
+    "expected #{actual} to track #{expected} action, but it didn't."
   end
 
   failure_message_when_negated do |actual|
-    "expected that #{actual} doesn't track #{expected} action, but it did."
+    "expected #{actual} not to track #{expected} action, but it did."
   end
 
 end


### PR DESCRIPTION
This PR changes the `have_action_tracker` matcher, to strictly verify the included concern and the before and after filters on the given controller.

Also, I've introduced another tracker, called `track`. The usage is like
`it { expect(controller).to track(:action)`
