### PR TITLE
NilResource implementation

### DIFF
--- a/lib/action_tracker.rb
+++ b/lib/action_tracker.rb
@@ -1,4 +1,5 @@
 require 'action_tracker/version'
+require 'action_tracker/nil_resource'
 require 'action_tracker/concerns/tracker'
 require 'action_tracker/helpers/render'
 require 'action_tracker/base'

--- a/lib/action_tracker/concerns/tracker.rb
+++ b/lib/action_tracker/concerns/tracker.rb
@@ -53,7 +53,7 @@ module ActionTracker
       def find_resource
         @resource_method ||= Devise.mappings.keys.map { |resource| "current_#{resource}" }
                                    .select { |method_name| !method(method_name).call.nil? }
-                                   .first
+                                   .first || 'nil_current_resource'
       rescue NameError
         nil
       end
@@ -74,6 +74,10 @@ module ActionTracker
 
       def namespace
         self.class.name.deconstantize.try(:+, '::')
+      end
+
+      def nil_current_resource
+        NilResource.new
       end
     end
   end

--- a/lib/action_tracker/nil_resource.rb
+++ b/lib/action_tracker/nil_resource.rb
@@ -1,0 +1,36 @@
+module ActionTracker
+  # nodoc
+  class NilResource
+    def method_missing(_name, *_args)
+      self
+    end
+
+    def respond_to_missing?(*_args)
+      true
+    end
+
+    def to_s
+      ''
+    end
+
+    def to_a
+      []
+    end
+
+    def to_str
+      to_s
+    end
+
+    def to_ary
+      to_a
+    end
+
+    def to_i
+      0
+    end
+
+    def present?
+      true
+    end
+  end
+end

--- a/spec/tracker_spec.rb
+++ b/spec/tracker_spec.rb
@@ -8,7 +8,7 @@ describe ActionTracker::Concerns::Tracker do
     @fake_session = {}
 
     allow_any_instance_of(ApplicationTestController).to receive(:session).and_return(@fake_session)
-    allow_any_instance_of(described_class).to receive(:resource).and_return(Object.new)
+    allow_any_instance_of(described_class).to receive(:resource).and_return(ActionTracker::NilResource.new)
     @helper = Object.new.extend ActionTracker::Helpers::Render
   end
 
@@ -47,11 +47,12 @@ describe ActionTracker::Concerns::Tracker do
 
   context 'when the resource does not exists' do
     before(:each) do
-      allow_any_instance_of(described_class).to receive(:resource).and_return(nil)
+      allow_any_instance_of(described_class).to receive(:find_resource).and_return('nil_current_resource')
     end
 
-    it 'returns a nil track' do
-      expect(@fake_session[:action_tracker]).to be_nil
+    it 'track events normally' do
+      trigger_trackers(%w(action_test))
+      expect(@fake_session[:action_tracker]).to match(['Here comes the test'])
     end
   end
 


### PR DESCRIPTION
This PR intends to provide a default empty resource to avoid breaking the application when no resource was previously set (and resource data are called). 

Sometimes makes sense to track actions where there is no resource previously set (like pages where the user is not authenticated) so we cannot just abort the tracking action.

Fixes #23 
